### PR TITLE
Feat/external ref table icon

### DIFF
--- a/public/icons/genes.svg
+++ b/public/icons/genes.svg
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="40"
+   height="40"
+   viewBox="0 0 40 40"
+   version="1.1"
+   id="svg9237"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+   <g
+      id="Gene"
+      transform="translate(27 -809) rotate(45)">
+   <path
+      id="Exclusion_2"
+      data-name="Exclusion 2"
+      d="M6.086,12.171a6.085,6.085,0,0,1-4.3-10.388,6.085,6.085,0,1,1,8.606,8.606A6.044,6.044,0,0,1,6.086,12.171Zm0-11.157a5.071,5.071,0,1,0,5.072,5.072A5.077,5.077,0,0,0,6.086,1.014Z"
+      transform="translate(567 584.331)"
+      fill="#233c68" />
+   <rect
+      id="Rectangle_260"
+      data-name="Rectangle 260"
+      width="10.142"
+      height="1.171"
+      transform="translate(568.014 591.607)"
+      fill="#233c68" />
+   <rect
+      id="Rectangle_259"
+      data-name="Rectangle 259"
+      width="10.142"
+      height="1.171"
+      transform="translate(568.014 588.057)"
+      fill="#233c68" />
+   <g
+      id="Group_479"
+      data-name="Group 479"
+      transform="translate(573.592 587.374)">
+      <circle
+         id="Ellipse_11"
+         data-name="Ellipse 11"
+         cx="1.268"
+         cy="1.268"
+         r="1.268"
+         transform="translate(0)"
+         fill="#233c68" />
+      <circle
+         id="Ellipse_12"
+         data-name="Ellipse 12"
+         cx="0.444"
+         cy="0.444"
+         r="0.444"
+         transform="translate(0.824 0.824)"
+         fill="#233c68" />
+   </g>
+   <g
+      id="Group_480"
+      data-name="Group 480"
+      transform="translate(570.042 590.924)">
+      <circle
+         id="Ellipse_11-2"
+         data-name="Ellipse 11"
+         cx="1.268"
+         cy="1.268"
+         r="1.268"
+         transform="translate(0 0)"
+         fill="#233c68" />
+      <circle
+         id="Ellipse_12-2"
+         data-name="Ellipse 12"
+         cx="0.444"
+         cy="0.444"
+         r="0.444"
+         transform="translate(0.824 0.824)"
+         fill="#233c68" />
+   </g>
+   <g
+      id="Group_482"
+      data-name="Group 482"
+      transform="translate(567 578.5)">
+      <path
+         id="Subtraction_1"
+         data-name="Subtraction 1"
+         d="M6.086,6.118a6.045,6.045,0,0,1-4.3-1.783A6.042,6.042,0,0,1,0,.033H1.015A5.038,5.038,0,0,0,2.5,3.617,5.038,5.038,0,0,0,6.086,5.1,5.077,5.077,0,0,0,11.158.033h1.013v0a6.042,6.042,0,0,1-1.783,4.3A6.039,6.039,0,0,1,6.086,6.118Z"
+         transform="translate(0 0.475)"
+         fill="#233c68" />
+      <rect
+         id="Rectangle_262"
+         data-name="Rectangle 262"
+         width="10.142"
+         height="1.171"
+         transform="translate(1.015 1.476)"
+         fill="#233c68" />
+      <circle
+         id="Ellipse_15"
+         data-name="Ellipse 15"
+         cx="0.507"
+         cy="0.507"
+         r="0.507"
+         transform="translate(0)"
+         fill="#233c68" />
+      <circle
+         id="Ellipse_16"
+         data-name="Ellipse 16"
+         cx="0.507"
+         cy="0.507"
+         r="0.507"
+         transform="translate(11.157)"
+         fill="#233c68" />
+      <g
+         id="Group_481"
+         data-name="Group 481"
+         transform="translate(3.043 0.793)">
+         <circle
+            id="Ellipse_11-3"
+            data-name="Ellipse 11"
+            cx="1.268"
+            cy="1.268"
+            r="1.268"
+            transform="translate(0 0)"
+            fill="#233c68" />
+         <circle
+            id="Ellipse_12-3"
+            data-name="Ellipse 12"
+            cx="0.444"
+            cy="0.444"
+            r="0.444"
+            transform="translate(0.824 0.824)"
+            fill="#233c68" />
+      </g>
+   </g>
+   <g
+      id="Group_483"
+      data-name="Group 483"
+      transform="translate(579.171 602.5) rotate(180)">
+      <path
+         id="Subtraction_1-2"
+         data-name="Subtraction 1"
+         d="M6.086,6.118a6.045,6.045,0,0,1-4.3-1.783A6.042,6.042,0,0,1,0,.033H1.015A5.038,5.038,0,0,0,2.5,3.617,5.038,5.038,0,0,0,6.086,5.1,5.077,5.077,0,0,0,11.158.033h1.013v0a6.042,6.042,0,0,1-1.783,4.3A6.039,6.039,0,0,1,6.086,6.118Z"
+         transform="translate(0 0.475)"
+         fill="#233c68" />
+      <rect
+         id="Rectangle_261"
+         data-name="Rectangle 261"
+         width="10.142"
+         height="1.171"
+         transform="translate(11.157 2.747) rotate(180)"
+         fill="#233c68" />
+      <circle
+         id="Ellipse_15-2"
+         data-name="Ellipse 15"
+         cx="0.507"
+         cy="0.507"
+         r="0.507"
+         transform="translate(0)"
+         fill="#233c68" />
+      <circle
+         id="Ellipse_16-2"
+         data-name="Ellipse 16"
+         cx="0.507"
+         cy="0.507"
+         r="0.507"
+         transform="translate(11.157)"
+         fill="#233c68" />
+      <g
+         id="Group_481-2"
+         data-name="Group 481"
+         transform="translate(3.043 0.893)">
+         <circle
+            id="Ellipse_11-4"
+            data-name="Ellipse 11"
+            cx="1.268"
+            cy="1.268"
+            r="1.268"
+            fill="#233c68" />
+         <circle
+            id="Ellipse_12-4"
+            data-name="Ellipse 12"
+            cx="0.444"
+            cy="0.444"
+            r="0.444"
+            transform="translate(0.824 0.824)"
+            fill="#233c68" />
+      </g>
+   </g>
+  </g>
+</svg>

--- a/src/components/Summary/SummaryHeader.stories.tsx
+++ b/src/components/Summary/SummaryHeader.stories.tsx
@@ -16,7 +16,8 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    headerTitleLeft: 'HeaderCategory',
+    iconPath: '/icons/gene-mutation.svg',
+    headerTitleLeft: 'Gene',
     headerTitle: 'HeaderTitle',
     isModal: false,
   },

--- a/src/components/Summary/SummaryHeader.tsx
+++ b/src/components/Summary/SummaryHeader.tsx
@@ -5,6 +5,7 @@ import { ReactNode } from 'react';
 import Image from 'next/image';
 
 export interface SummaryHeaderProps {
+  iconPath: string;
   headerTitleLeft: string;
   headerTitle: string | number;
   leftElement?: ReactNode;
@@ -12,8 +13,9 @@ export interface SummaryHeaderProps {
   isModal?: boolean;
 }
 export const SummaryHeader = ({
-
-                                headerTitleLeft, headerTitle,
+  iconPath,
+  headerTitleLeft,
+  headerTitle,
   leftElement,
   rightElement,
   isModal = false,
@@ -32,7 +34,7 @@ export const SummaryHeader = ({
         >
           <Image
             className="ml-[8px] mt-[11px]"
-            src="/icons/gene-mutation.svg"
+            src={iconPath}
             alt=""
             height={40}
             width={40}

--- a/src/components/Summary/SummaryHeader.tsx
+++ b/src/components/Summary/SummaryHeader.tsx
@@ -41,7 +41,7 @@ export const SummaryHeader = ({
             data-testid="summary-header-icon"
           />
         </span>
-        <SummaryHeaderTitle data-testid="summary-header-title">
+        <SummaryHeaderTitle data-testid="summary-header-title" className='uppercase'>
           {headerTitleLeft} <span className="mx-4 text-2xl inline">•</span>{' '}
           {headerTitle}
         </SummaryHeaderTitle>

--- a/src/features/GeneSummary/GeneSummary.tsx
+++ b/src/features/GeneSummary/GeneSummary.tsx
@@ -269,7 +269,7 @@ const GeneView = ({
       {data && (
         <>
           <SummaryHeader
-            // Icon={GenesIcon}
+            iconPath='/icons/genes.svg'
             headerTitleLeft="GENE"
             headerTitle={data.symbol}
             isModal={isModal}

--- a/src/features/mutationSummary/SSMSSummary.tsx
+++ b/src/features/mutationSummary/SSMSSummary.tsx
@@ -174,8 +174,9 @@ export const SSMSSummary = ({
       ) : summaryData ? (
         <>
           <SummaryHeader
-            headerTitleLeft="MUTATION"
+            iconPath="/icons/gene-mutation.svg"
             headerTitle={summaryData.dna_change}
+            headerTitleLeft="Mutation"
             isModal={isModal}
           />
 


### PR DESCRIPTION
Link to JIRA ticket if there is one: 
https://ctds-planx.atlassian.net/browse/GFF-308

**Dev Notes:** 
Adds class name uppercase to SummaryHeaderTitle so Summary Header titles always render in uppercase

Mutation Page with Gene Mutation Icon 
<img width="458" alt="image" src="https://github.com/user-attachments/assets/02267f65-bcfa-483c-9836-494ed5544d57" />

Gene Page with Gene Icon
<img width="458" alt="image" src="https://github.com/user-attachments/assets/297c167e-4736-4186-9f75-b87a9c0de76a" />


### New Features
* Allows Summary Header to display different icons
